### PR TITLE
tabs highlighted under create, edit and details.

### DIFF
--- a/app/network_policies/networkpoliciestabs.html
+++ b/app/network_policies/networkpoliciestabs.html
@@ -7,10 +7,10 @@
 
     <div style="margin-top:30px"></div>
     <div class="ui secondary pointing menu">
-        <a class="blue item" ui-sref="contiv.menu.networkpolicies.isolation.list()" ui-sref-active="active">
+        <a class="blue item" ui-sref="contiv.menu.networkpolicies.isolation.list()" ui-sref-active="{'active':'contiv.menu.networkpolicies.isolation'}">
             Isolation Policies
         </a>
-        <a class="blue item" ui-sref="contiv.menu.networkpolicies.bandwidth.list()" ui-sref-active="active">
+        <a class="blue item" ui-sref="contiv.menu.networkpolicies.bandwidth.list()" ui-sref-active="{'active':'contiv.menu.networkpolicies.bandwidth'}">
             Bandwidth Policies
         </a>
         <a class="blue item" ui-sref="contiv.menu.networkpolicies.redirection()" ui-sref-active="active">


### PR DESCRIPTION
Fixed : [Network Policies] Isolation policy tab is not highlighted in details/edit view #40
