### PR TITLE
Display group tag in application group list table

### DIFF
--- a/app/applicationgroups/applicationgrouplist.html
+++ b/app/applicationgroups/applicationgrouplist.html
@@ -40,6 +40,7 @@
                         <th><ctv-th [sortfield]="'tenantName'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Tenant</ctv-th></th>
                         <th><ctv-th [sortfield]="'networkName'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Network</ctv-th></th>
                         <th><ctv-th [sortfield]="'policies'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Policies</ctv-th></th>
+                        <th><ctv-th [sortfield]="'cfgdTag'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Group Tag</ctv-th></th>
                     </tr>
                 </thead>
 
@@ -49,6 +50,7 @@
                     <td>{{group.tenantName}}</td>
                     <td>{{group.networkName}}</td>
                     <td>{{group.policies.join(", ")}}</td>
+                    <td>{{group.cfgdTag}}</td>
                     </tr>
                 </tbody>
 

--- a/app/networks/networklist.html
+++ b/app/networks/networklist.html
@@ -42,6 +42,7 @@
                         <th><ctv-th [sortfield]="'encap'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Encapsulation</ctv-th></th>
                         <th><ctv-th [sortfield]="'subnet'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Subnet</ctv-th></th>
                         <th><ctv-th [sortfield]="'gateway'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Gateway</ctv-th></th>
+                        <th><ctv-th [sortfield]="'cfgdTag'" (sortdata)="tableRef.applysort($event)" [sortobject]="tableRef.sortObj">Tag</ctv-th></th>
                     </tr>
                     </thead>
 
@@ -52,6 +53,7 @@
                         <td>{{network.encap}}</td>
                         <td>{{network.subnet}}</td>
                         <td>{{network.gateway}}</td>
+                        <td>{{network.cfgdTag}}</td>
                     </tr>
                     </tbody>
 


### PR DESCRIPTION
Current, group tag is not displayed in the list table. This PR is
to display it along with other group fields

Signed-off-by: Kahou Lei <kalei@cisco.com>